### PR TITLE
Use .get instead of index in student portal

### DIFF
--- a/backend/routes/student/index.py
+++ b/backend/routes/student/index.py
@@ -86,7 +86,7 @@ class StudentPortal(Route):
 
         for cm in classes:
             for task in cm.cls.tasks:
-                if completion_dict[task.id] != "complete":
+                if completion_dict.get(task.id) != "complete":
                     tasks.append(task)
 
         tasks_by_date = groupby(tasks, lambda task: self.format_date(task.due_at))


### PR DESCRIPTION
The completions PR hid completed tasks from the student view. It introduced a bug since it assumed all tasks had a completion status, when in actuality the default state is for them not to have one.

This PR adds a fallback get instead of an index to prevent a 500 error or a KeyError.