### PR TITLE
Remove parents type

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -31,14 +31,13 @@ class UserType(Enum):
 
     STUDENT = "student"
     TEACHER = "teacher"
-    PARENT = "parent"
 
 
 class User(db.Model):
     """
     Class for base users.
 
-    This encompasses teachers, students and parents.
+    This encompasses teachers and students
     """
 
     __tablename__ = "users"

--- a/backend/routes/users/sign_up.py
+++ b/backend/routes/users/sign_up.py
@@ -53,7 +53,7 @@ class UserSignUp(Route):
         elif u_type == "teacher":
             parsed_type = UserType.TEACHER
         else:
-            parsed_type = UserType.PARENT
+            raise Exception("Unknown type provided")
 
         return parsed_type
 
@@ -99,7 +99,7 @@ class UserSignUp(Route):
         for key in self._validate_required(request.form):
             errors[key] = f"{key.replace('_', ' ').capitalize()} is not present"
 
-        if request.form.get("type") not in ["student", "teacher", "parent"]:
+        if request.form.get("type") not in ["student", "teacher"]:
             # If the passed type is not of one in the above list, raise 400
             errors["type"] = "Invalid type"
 

--- a/backend/templates/users/sign_up.html
+++ b/backend/templates/users/sign_up.html
@@ -41,12 +41,7 @@
           <label class="type-select">
             <input type="radio" value="student" name="type">
             <span>&nbsp;Student</span>
-          </label>
-
-          <label class="type-select">
-            <input type="radio" value="parent" name="type">
-            <span>&nbsp;Parent</span>
-          </label>
+          </label
 
           <input name="g-recaptcha" id="g-recaptcha" hidden/>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/migrations/versions/79814ff114c9_remove_parents.py
+++ b/migrations/versions/79814ff114c9_remove_parents.py
@@ -1,0 +1,41 @@
+"""Remove parents
+
+Revision ID: 79814ff114c9
+Revises: 1f84d2da2b69
+Create Date: 2020-11-09 09:52:05.820396
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '79814ff114c9'
+down_revision = '1f84d2da2b69'
+branch_labels = None
+depends_on = None
+
+
+enum_name = 'usertype'
+
+tmp_enum_name = 'tmp_' + enum_name
+
+old_options = ('STUDENT', 'TEACHER', 'PARENT')
+new_options = ('STUDENT', 'TEACHER')
+
+old_type = sa.Enum(*old_options, name=enum_name)
+new_type = sa.Enum(*new_options, name=enum_name)
+
+def upgrade():
+    # Rename current enum type to tmp_
+    op.execute('ALTER TYPE ' + enum_name + ' RENAME TO ' + tmp_enum_name)
+    # Create new enum type in db
+    new_type.create(op.get_bind())
+    # Update column to use new enum type
+    op.execute('ALTER TABLE users ALTER COLUMN type TYPE ' + enum_name + ' USING type::text::' + enum_name)
+    # Drop old enum type
+    op.execute('DROP TYPE ' + tmp_enum_name)
+
+
+def downgrade():
+    pass

--- a/tests/routes/users/test_sign_up.py
+++ b/tests/routes/users/test_sign_up.py
@@ -72,7 +72,6 @@ def test_type_parse() -> None:
     """Test the parsing of types into enumerables."""
     assert UserSignUp._parse_type("teacher") is UserType.TEACHER
     assert UserSignUp._parse_type("student") is UserType.STUDENT
-    assert UserSignUp._parse_type("parent") is UserType.PARENT
 
 
 def test_unique_constraint_parser() -> None:


### PR DESCRIPTION
This PR removes the parent type since the logic is not implemented and it is a feature to work on in future.

It removes the option form, the enum variant from the database and the validations from the sign up logic.